### PR TITLE
refactor: use admin API for dashboard

### DIFF
--- a/app/src/screens/admin/AdminDashboardScreen.js
+++ b/app/src/screens/admin/AdminDashboardScreen.js
@@ -16,7 +16,7 @@ import { LineChart, BarChart, PieChart } from 'react-native-chart-kit';
 import { theme } from '../../theme/theme';
 import { useLanguage } from '../../context/LanguageContext';
 import { useAuth } from '../../context/AuthContext';
-import { usersAPI, flagsAPI } from '../../services/api';
+import { adminAPI, flagsAPI } from '../../services/api';
 
 const { width } = Dimensions.get('window');
 
@@ -42,7 +42,7 @@ export default function AdminDashboardScreen() {
       setLoading(true);
       
       // Load admin dashboard data
-      const response = await usersAPI.getAdminDashboard({
+      const response = await adminAPI.getDashboard({
         period: selectedPeriod,
       });
       


### PR DESCRIPTION
## Summary
- use `adminAPI.getDashboard` for admin dashboard data

## Testing
- `npm test`
- `npm run lint` *(fails: Trailing spaces, prettier violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6d54e04832ba814a46e8e8de872