### PR TITLE
Add basic tests for HomeScreen and AuthContext

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -75,6 +75,8 @@
         "@babel/runtime": "^7.20.0",
         "@react-native/eslint-config": "^0.72.2",
         "@react-native/metro-config": "^0.72.11",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^13.3.3",
         "@tsconfig/react-native": "^3.0.0",
         "@types/react": "~18.2.14",
         "@types/react-native": "^0.72.6",
@@ -3949,6 +3951,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -4006,6 +4018,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -7770,6 +7792,175 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
+      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
+      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.40",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
+      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
+      "integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
+      "integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.1.1",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/react-native": {
@@ -17635,6 +17826,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -23822,6 +24023,20 @@
         "react-native": ">= 0.30.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -25743,6 +25958,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
     "build:android": "expo build:android",
     "build:ios": "expo build:ios",
     "eject": "expo eject",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
@@ -96,6 +96,8 @@
     "@babel/runtime": "^7.20.0",
     "@react-native/eslint-config": "^0.72.2",
     "@react-native/metro-config": "^0.72.11",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.3.3",
     "@tsconfig/react-native": "^3.0.0",
     "@types/react": "~18.2.14",
     "@types/react-native": "^0.72.6",
@@ -113,6 +115,10 @@
     "typescript": "^5.1.3"
   },
   "private": true,
+  "jest": {
+    "preset": "react-native",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
+  },
   "expo": {
     "name": "Afghanistan Marketplace",
     "slug": "afghanistan-marketplace",

--- a/app/src/__tests__/AuthContext.test.js
+++ b/app/src/__tests__/AuthContext.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { AuthProvider, useAuth } from '../context/AuthContext';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { authAPI } from '../services/api';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(),
+  getItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../services/api', () => ({
+  authAPI: {
+    login: jest.fn(),
+  },
+}));
+
+jest.mock('react-native-flash-message', () => ({
+  showMessage: jest.fn(),
+}));
+
+describe('AuthContext', () => {
+  it('stores token and user on successful login', async () => {
+    authAPI.login.mockResolvedValue({
+      success: true,
+      token: 'abc123',
+      user: { id: 1, name: 'John' },
+    });
+
+    let context;
+    const Capture = () => {
+      context = useAuth();
+      return null;
+    };
+
+    render(
+      <AuthProvider>
+        <Capture />
+      </AuthProvider>
+    );
+
+    await act(async () => {
+      await context.login('test@example.com', 'password');
+    });
+
+    expect(context.user).toEqual({ id: 1, name: 'John' });
+    expect(context.token).toBe('abc123');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('token', 'abc123');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('user', JSON.stringify({ id: 1, name: 'John' }));
+  });
+});

--- a/app/src/__tests__/HomeScreen.test.js
+++ b/app/src/__tests__/HomeScreen.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import HomeScreen from '../screens/HomeScreen';
+
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Test' } }),
+}));
+
+jest.mock('../context/LanguageContext', () => ({
+  useLanguage: () => ({ t: (key) => key }),
+}));
+
+jest.mock('../services/api', () => ({
+  productsAPI: { getProducts: jest.fn().mockResolvedValue({ success: true, data: [] }) },
+  storesAPI: { getStores: jest.fn().mockResolvedValue({ success: true, data: [] }) },
+  categoriesAPI: { getFeaturedCategories: jest.fn().mockResolvedValue({ success: true, data: [] }) },
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+jest.mock('react-native-gesture-handler', () => ({
+  FlatList: ({ children }) => null,
+}));
+
+describe('HomeScreen', () => {
+  it('renders search input', async () => {
+    const { getByPlaceholderText } = render(<HomeScreen />);
+    await waitFor(() => {
+      expect(getByPlaceholderText('home.searchPlaceholder')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add initial HomeScreen rendering test
- cover AuthContext login flow and storage
- configure Jest and testing libraries for app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7010e44832bb527ba1b8a903cec