### PR TITLE
Use secure storage for auth data

### DIFF
--- a/app/src/__tests__/AuthContext.test.js
+++ b/app/src/__tests__/AuthContext.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
 import { AuthProvider, useAuth } from '../context/AuthContext';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as storage from '../services/storage';
 import { authAPI } from '../services/api';
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
+jest.mock('../services/storage', () => ({
   setItem: jest.fn(),
   getItem: jest.fn(),
   removeItem: jest.fn(),
@@ -46,7 +46,7 @@ describe('AuthContext', () => {
 
     expect(context.user).toEqual({ id: 1, name: 'John' });
     expect(context.token).toBe('abc123');
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith('token', 'abc123');
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith('user', JSON.stringify({ id: 1, name: 'John' }));
+    expect(storage.setItem).toHaveBeenCalledWith('token', 'abc123');
+    expect(storage.setItem).toHaveBeenCalledWith('user', JSON.stringify({ id: 1, name: 'John' }));
   });
 });

--- a/app/src/context/AuthContext.js
+++ b/app/src/context/AuthContext.js
@@ -24,8 +24,8 @@ export const AuthProvider = ({ children }) => {
 
   const checkAuthState = async () => {
     try {
-      const storedToken = await AsyncStorage.getItem('token');
-      const storedUser = await AsyncStorage.getItem('user');
+      const storedToken = await getItem('token');
+      const storedUser = await getItem('user');
       if (storedToken && storedUser) {
         setToken(storedToken);
         setUser(JSON.parse(storedUser));
@@ -45,8 +45,8 @@ export const AuthProvider = ({ children }) => {
 
       if (response.success) {
         const { token: newToken, user: newUser } = response;
-        await AsyncStorage.setItem('token', newToken);
-        await AsyncStorage.setItem('user', JSON.stringify(newUser));
+        await setItem('token', newToken);
+        await setItem('user', JSON.stringify(newUser));
         
         setToken(newToken);
         setUser(newUser);
@@ -88,8 +88,8 @@ export const AuthProvider = ({ children }) => {
       if (response.success) {
         const { token: newToken, user: newUser } = response;
 
-        await AsyncStorage.setItem('token', newToken);
-        await AsyncStorage.setItem('user', JSON.stringify(newUser));
+        await setItem('token', newToken);
+        await setItem('user', JSON.stringify(newUser));
 
         setToken(newToken);
         setUser(newUser);
@@ -131,8 +131,8 @@ export const AuthProvider = ({ children }) => {
         await authAPI.logout();
       }
       
-      await AsyncStorage.removeItem('token');
-      await AsyncStorage.removeItem('user');
+      await removeItem('token');
+      await removeItem('user');
 
       setToken(null);
       setUser(null);
@@ -157,7 +157,7 @@ export const AuthProvider = ({ children }) => {
 
       if (response.success) {
         const updatedUser = response.user;
-        await AsyncStorage.setItem('user', JSON.stringify(updatedUser));
+        await setItem('user', JSON.stringify(updatedUser));
         setUser(updatedUser);
 
         showMessage({

--- a/app/src/services/socketService.js
+++ b/app/src/services/socketService.js
@@ -9,7 +9,7 @@ class SocketService {
 
   async connect() {
     try {
-      const token = await AsyncStorage.getItem('token');
+      const token = await getItem('token');
       const API_URL =
         process.env.EXPO_PUBLIC_API_URL || 'http://localhost:4000';
 


### PR DESCRIPTION
## Summary
- Replace AsyncStorage with secure store helpers for tokens and user data
- Align socket service and tests with new secure storage API

## Testing
- `npm test` (api)
- `npm test` (app)


------
https://chatgpt.com/codex/tasks/task_e_68b2059e9ac8832b9869fd5d3ad28025